### PR TITLE
Successful subscription state is now stored during screen rotation

### DIFF
--- a/HelloBeacons-Display-Messages/app/src/main/java/com/google/android/gms/nearby/messages/samples/hellobeacons/MainActivity.java
+++ b/HelloBeacons-Display-Messages/app/src/main/java/com/google/android/gms/nearby/messages/samples/hellobeacons/MainActivity.java
@@ -233,6 +233,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
                     public void onResult(@NonNull Status status) {
                         if (status.isSuccess()) {
                             Log.i(TAG, "Subscribed successfully.");
+                            mSubscribed = true;
                             startService(getBackgroundSubscribeServiceIntent());
                         } else {
                             Log.e(TAG, "Operation failed. Error: " +


### PR DESCRIPTION
Fix of the issue https://github.com/googlecodelabs/hello-beacons/issues/4.

Now subscription state is stored during screen rotation